### PR TITLE
Add time tracking and dynamic energy drain

### DIFF
--- a/pause_menu.gd
+++ b/pause_menu.gd
@@ -7,10 +7,12 @@ func _on_resume_button_pressed() -> void:
 func _on_restart_button_pressed() -> void:
 	Game.update_game_state.emit(Utils.GameStateType.Play)
 	get_tree().change_scene_to_file("res://scenes/Main.tscn")
+	Game.reset_stats()
 
 func _on_main_menu_button_pressed() -> void:
 	Game.update_game_state.emit(Utils.GameStateType.Play)
 	get_tree().change_scene_to_file("res://scenes/MainMenu.tscn")
+	Game.reset_stats()
 	
 func _on_quit_button_pressed() -> void:
 	get_tree().quit()

--- a/scenes/Energy.tscn
+++ b/scenes/Energy.tscn
@@ -1,9 +1,20 @@
-[gd_scene load_steps=2 format=3 uid="uid://decqbrmnhe0kb"]
+[gd_scene load_steps=3 format=3 uid="uid://decqbrmnhe0kb"]
 
 [ext_resource type="Script" uid="uid://clw2lea18gqug" path="res://scripts/energy.gd" id="1_eb132"]
+[ext_resource type="Script" path="res://scenes/TimeLabel..gd" id="2_t2csp"]
 
 [node name="EnergyBar" type="ProgressBar"]
-offset_right = 425.0
-offset_bottom = 35.0
+offset_left = 75.0
+offset_top = 2.0
+offset_right = 500.0
+offset_bottom = 37.0
 step = 1.0
 script = ExtResource("1_eb132")
+
+[node name="Label2" type="Label" parent="."]
+layout_mode = 0
+offset_left = -66.0
+offset_top = 4.0
+offset_right = -6.0
+offset_bottom = 34.0
+script = ExtResource("2_t2csp")

--- a/scenes/TimeLabel..gd
+++ b/scenes/TimeLabel..gd
@@ -1,0 +1,9 @@
+extends Label
+
+func _ready() -> void:
+	Game.time_changed.connect(update_time)
+
+func update_time(time: float) -> void:
+	var minutes = int(time) / 60
+	var seconds = int(time) % 60
+	text = "%02d:%02d" % [minutes, seconds]

--- a/scenes/TimeLabel..gd.uid
+++ b/scenes/TimeLabel..gd.uid
@@ -1,0 +1,1 @@
+uid://ceyfbkxcw2y5t

--- a/scripts/energy.gd
+++ b/scripts/energy.gd
@@ -7,3 +7,4 @@ func _ready() -> void:
 
 func change_energy_value(energy: int):
 	value = energy
+	

--- a/scripts/game.gd
+++ b/scripts/game.gd
@@ -1,42 +1,84 @@
 extends Node
 
 var energy = 0
+var elapsed_time: float = 0.0  
+var base_wait_time: float = 10.0   
+var base_decrease: int = 1       
+var difficulty_step: float = 30.0 
 
 signal trash_collected(type: Utils.TrashType)
+signal energy_changed(value: int)
+signal updated_stats
+signal time_changed(time: float)
+signal update_ui_state(type: Utils.UIStateType)
+signal update_game_state(type: Utils.GameStateType)
 
 var collected_biodegradable = 0
 var collected_recyclable = 0
 var collected_toxic_waste = 0
 
+var energy_timer: Timer
+
 func _ready() -> void:
 	trash_collected.connect(update_trash_count)
 
-signal energy_changed(value: int)
+	energy_timer = Timer.new()
+	energy_timer.wait_time = base_wait_time
+	energy_timer.one_shot = false
+	energy_timer.autostart = true
+	add_child(energy_timer)
+	energy_timer.timeout.connect(_on_energy_timer_timeout)
+
+	set_process(true)
+
+func _process(delta: float) -> void:
+	elapsed_time += delta
+	time_changed.emit(elapsed_time)
+
+	var difficulty_level = int(elapsed_time / difficulty_step)
+
+
+	energy_timer.wait_time = max(1.0, base_wait_time - difficulty_level)  
+
+	# scale energy drain (more lost per tick)
+	base_decrease = 1 + difficulty_level  
 
 func add_energy(amount: float) -> void:
 	energy += amount
 	energy_changed.emit(energy)
 
-signal updated_stats
+func decrease_energy(amount: float) -> void:
+	energy = max(0, energy - amount)
+	energy_changed.emit(energy)
+
+func _on_energy_timer_timeout() -> void:
+	decrease_energy(base_decrease)
 
 func update_trash_count(type: Utils.TrashType):
 	if type == Utils.TrashType.Recyclable:
 		collected_recyclable += 1
 		add_energy(2)
-	if type == Utils.TrashType.Biodegradable:
+		energy_timer.start()
+
+	elif type == Utils.TrashType.Biodegradable:
 		collected_biodegradable += 1
 		add_energy(3)
-	if type == Utils.TrashType.ToxicWaste:
+		energy_timer.start()
+
+	elif type == Utils.TrashType.ToxicWaste:
 		collected_toxic_waste += 1
 		add_energy(5)
-	updated_stats.emit()
+		energy_timer.start()
 
-signal update_ui_state(type: Utils.UIStateType)
-signal update_game_state(type: Utils.GameStateType)
+	updated_stats.emit()
 
 func reset_stats():
 	collected_recyclable = 0
 	collected_biodegradable = 0
 	collected_toxic_waste = 0
 	energy = 0
+	elapsed_time = 0.0
 	updated_stats.emit()
+	energy_changed.emit(energy)
+	energy_timer.start()
+	time_changed.emit(elapsed_time)


### PR DESCRIPTION
Introduces elapsed time tracking and difficulty scaling in game.gd, with a timer that decreases energy at increasing rates as time progresses. Adds a TimeLabel script and node to display elapsed time, updates Energy.tscn layout, and ensures stats and timers reset when restarting or returning to main menu.